### PR TITLE
Fix issue where child context was replacing instead of augmenting parent context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ export default function renderToString(vnode, context, opts, inner) {
 				rendered = c.render(c.props, c.state, c.context);
 
 				if (c.getChildContext) {
-					context = c.getChildContext();
+					context = assign(assign({}, context), c.getChildContext());
 				}
 			}
 


### PR DESCRIPTION
To ensure this behaves the same as `preact` I just brought over and updated the relevant tests from there. Happy to make any alterations.