### PR TITLE
add support for render(obj) where obj has a toJSON method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ let shallowRender = (vnode, context) => renderToString(vnode, context, SHALLOW);
 
 /** The default export is an alias of `render()`. */
 export default function renderToString(vnode, context, opts, inner) {
-	let { nodeName, attributes, children } = vnode || EMPTY;
+	let { nodeName, attributes, children } = toVNode(vnode);
 	context = context || {};
 	opts = opts || {};
 
@@ -183,6 +183,14 @@ export default function renderToString(vnode, context, opts, inner) {
 	}
 
 	return s;
+}
+
+function toVNode(vnode) {
+	if (!vnode) return EMPTY;
+
+	return vnode.hasOwnProperty('toJSON')
+		? vnode.toJSON()
+		: vnode;
 }
 
 function getComponentName(component) {

--- a/test/render.js
+++ b/test/render.js
@@ -436,4 +436,12 @@ describe('render', () => {
 			expect(renderXml(<div foo={false} bar={0} />)).to.equal(`<div bar="0" />`);
 		});
 	});
+
+	describe('objects with toJSON', () => {
+		it('should render objects with toJSON', () => {
+			let obj = { toJSON: () => { return { nodeName: 'div' }; } };
+			let rendered = render(obj);
+			expect(rendered).to.equal('<div></div>');
+		});
+	});
 });


### PR DESCRIPTION
This PR will allow you to pass in objects into render and if they have a `toJSON` property, it will call that first.

It allows you to do fancy things like this:

``` js
const App => (
  div.class('box')({ custom: true })
)

let src = render(App)
// <div class="box" custom></div>
```

Let me know if you're down for this feature or if there's anything you'd like me to change! If this works for you I'll start opening PRs for the other renderers.
