### PR TITLE
SVG XLink attributes are rendered incorrectly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,8 @@ export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 		for (let i=0; i<len; i++) {
 			let child = children[i];
 			if (!falsey(child)) {
-				let ret = renderToString(child, context, opts, true, nodeName==='svg');
+				let childSvgMode = nodeName==='svg' ? true : nodeName==='foreignObject' ? false : isSvgMode,
+					ret = renderToString(child, context, opts, true, childSvgMode);
 				if (!hasLarge && pretty && isLargeString(ret)) hasLarge = true;
 				pieces.push(ret);
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ let shallowRender = (vnode, context) => renderToString(vnode, context, SHALLOW);
 
 
 /** The default export is an alias of `render()`. */
-export default function renderToString(vnode, context, opts, inner) {
+export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 	let { nodeName, attributes, children } = vnode || EMPTY,
 		isComponent = false;
 	context = context || {};
@@ -117,6 +117,9 @@ export default function renderToString(vnode, context, opts, inner) {
 				if (attributes['class']) continue;
 				name = 'class';
 			}
+			else if (isSvgMode && name.match(/^xlink\:?(.+)/)) {
+				name = name.toLowerCase().replace(/^xlink\:?(.+)/, 'xlink:$1')
+			}
 
 			if (name==='class' && v && typeof v==='object') {
 				v = hashToClassName(v);
@@ -169,7 +172,7 @@ export default function renderToString(vnode, context, opts, inner) {
 		for (let i=0; i<len; i++) {
 			let child = children[i];
 			if (!falsey(child)) {
-				let ret = renderToString(child, context, opts, true);
+				let ret = renderToString(child, context, opts, true, nodeName==='svg');
 				if (!hasLarge && pretty && isLargeString(ret)) hasLarge = true;
 				pieces.push(ret);
 			}

--- a/test/render.js
+++ b/test/render.js
@@ -73,10 +73,19 @@ describe('render', () => {
 		});
 
 		it('should render SVG elements', () => {
-			let rendered = render(<svg viewBox="0 0 360 360"><use xlinkHref="#foo"></use></svg>),
-				expected = `<svg viewBox="0 0 360 360"><use xlink:href="#foo"></use></svg>`;
+			let rendered = render((
+				<svg>
+					<image xlinkHref="#" />
+					<foreignObject>
+						<div xlinkHref="#" />
+					</foreignObject>
+					<g>
+						<image xlinkHref="#" />
+					</g>
+				</svg>
+			));
 
-			expect(rendered).to.equal(expected);
+			expect(rendered).to.equal(`<svg><image xlink:href="#"></image><foreignObject><div xlinkHref="#"></div></foreignObject><g><image xlink:href="#"></image></g></svg>`);
 		});
 	});
 

--- a/test/render.js
+++ b/test/render.js
@@ -71,6 +71,13 @@ describe('render', () => {
 
 			expect(rendered).to.equal(expected);
 		});
+
+		it('should render SVG elements', () => {
+			let rendered = render(<svg viewBox="0 0 360 360"><use xlinkHref="#foo"></use></svg>),
+				expected = `<svg viewBox="0 0 360 360"><use xlink:href="#foo"></use></svg>`;
+
+			expect(rendered).to.equal(expected);
+		});
 	});
 
 	describe('Functional Components', () => {


### PR DESCRIPTION
Hello! XLink attributes on SVG elements don't seem to be transformed. For example `<use xlinkHref="#foo">` is being rendered as-is, when Preact renders it (correctly) as `<use xlink:href="#foo">`.

I'm going to attempt to fix it myself, but in the meantime please enjoy this failing test case:

```
  1) render Basic JSX should render SVG elements:

      AssertionError: expected '<svg viewBox="0 0 360 360"><use xlinkHref="#foo"></use></svg>' to equal '<svg viewBox="0 0 360 360"><use xlink:href="#foo"></use></svg>'
      + expected - actual

      -<svg viewBox="0 0 360 360"><use xlinkHref="#foo"></use></svg>
      +<svg viewBox="0 0 360 360"><use xlink:href="#foo"></use></svg>

      at Context.<anonymous> (test/render.js:79:24)
```
