### PR TITLE
handle arrays as class attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export default function renderToString(vnode, context, opts, inner) {
 			}
 
 			if (name==='class' && v && typeof v==='object') {
-				v = hashToClassName(v);
+				v = Array.isArray(v) ? v.filter(v => v).join(' ') : hashToClassName(v);
 			}
 			else if (name==='style' && v && typeof v==='object') {
 				v = styleObjToCss(v);

--- a/test/render.js
+++ b/test/render.js
@@ -413,6 +413,26 @@ describe('render', () => {
 			rendered = render(<div className={{ foo:1, bar:0, baz:true, buzz:false }} />);
 			expect(rendered, 'className').to.equal('<div class="foo baz"></div>');
 		});
+
+		it('should stringify array classNames', () => {
+			let vnode = {
+				nodeName: 'div',
+				attributes: { class: [ 'foo', 'baz' ] },
+				children: [],
+				key: undefined
+			};
+			let rendered = render(vnode);
+			expect(rendered, 'class').to.equal('<div class="foo baz"></div>');
+
+			vnode = {
+				nodeName: 'div',
+				attributes: { className: [ 'foo', false, 0, 'baz' ] },
+				children: [],
+				key: undefined
+			};
+			rendered = render(vnode);
+			expect(rendered, 'className').to.equal('<div class="foo baz"></div>');
+		});
 	});
 
 	describe('sortAttributes', () => {


### PR DESCRIPTION
This PR allows arrays to be passed into class attributes and joined together. 

I think JSX does this for you, but if you're not using JSX it ends up turning arrays into `class={["foo", "baz"]}` to `class="0 1"`.

Unrelated, but there was another test that was failing on master: 
<img width="945" alt="screenshot 2016-11-06 01 43 13" src="https://cloud.githubusercontent.com/assets/170299/20032682/79756d46-a3c2-11e6-9377-106ff9d946d7.png">. Wasn't exactly sure how to fix that.
