### PR TITLE
feat: add an option to change attributes with a hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,11 @@ export default function renderToString(vnode, context, opts, inner) {
 				name = 'class';
 			}
 
+			let valueHook = opts.attributeValueHook && opts.attributeValueHook(name, v, context, opts, isComponent);
+			if (valueHook !== undefined) {
+				v = valueHook || '';
+			}
+
 			if (name==='class' && v && typeof v==='object') {
 				v = hashToClassName(v);
 			}


### PR DESCRIPTION
This allows you to hook into the attribute rendering process. Unlike the `attributeHook`, this one allows you to handle the class attribute yourself before the internal `hashToClassName(v)`, `styleObjToCss(v)` take over. It also is a bit higher-level than `attributeHook`, which IMO is more useful.

I'd actually recommend replacing `attributeHook` with this implementation and removing `hashToClassName(v)`, `styleObjToCss(v)` altogether (allowing that stuff to happen in userland). 

I'm not sure of the ramifications on existing code for that recommendation though, so this is a non-breaking change.

*Note:* I'm not at all attached to `attributeValueHook`, in fact there are probably much better, less verbose names for that option.

It works like this:

```js
let html = render(vnodes, {}, {
  attributeValueHook: function (name, v) {
    if (name === 'class' && v === 'original') return 'replacement'
  }
})
```