### PR TITLE
Render empty value if render returns false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 	let pretty = opts.pretty,
 		indentChar = typeof pretty==='string' ? pretty : '\t';
 
-	if (vnode==null) {
+	if (vnode==null || vnode===false) {
 		return '';
 	}
 

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -125,17 +125,20 @@ describe('jsx', () => {
 
 	it('should render empty resolved children identically to no children', () => {
 		const Empty = () => null;
+		const False = () => false;
 		expect(renderJsx(
 			<div>
 				<a />
 				<b>{null}</b>
 				<c><Empty /></c>
+				<d><False /></d>
 			</div>
 		)).to.equal(dedent`
 			<div>
 				<a></a>
 				<b></b>
 				<c></c>
+				<d></d>
 			</div>
 		`);
 	});

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -131,7 +131,8 @@ describe('jsx', () => {
 				<a />
 				<b>{null}</b>
 				<c><Empty /></c>
-				<d><False /></d>
+				<d>{false}</d>
+				<e><False /></e>
 			</div>
 		)).to.equal(dedent`
 			<div>
@@ -139,6 +140,7 @@ describe('jsx', () => {
 				<b></b>
 				<c></c>
 				<d></d>
+				<e></e>
 			</div>
 		`);
 	});


### PR DESCRIPTION
[React supports](https://facebook.github.io/react/docs/react-component.html#render) returning `null` or `false` from a render function to indicate nothing to render.

Currently returning false during a server render will render the string ‘false’. 

As we use inline conditional rendering quite heavily e.g. `return condition && <div>yo</div>`this is causing our server renders with `preact-compat` to surface a fair amount of these unwanted strings.