### PR TITLE
Close void tags with slashes to support XHTML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 	s = `<${nodeName}${s}>`;
 
 	if (VOID_ELEMENTS.indexOf(nodeName)>-1) {
-		s = s.replace(/>$/, '/>');
+		s = s.replace(/>$/, ' />');
 	}
 
 	if (html) {

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,10 @@ export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 
 	s = `<${nodeName}${s}>`;
 
+	if (VOID_ELEMENTS.indexOf(nodeName)>-1) {
+		s = s.replace(/>$/, '/>');
+	}
+
 	if (html) {
 		// if multiline, indent.
 		if (pretty && isLargeString(html)) {

--- a/test/pretty.js
+++ b/test/pretty.js
@@ -55,7 +55,7 @@ describe('pretty', () => {
 				<img src="b.jpg" />
 				<b>hi</b>
 			</div>
-		)).to.equal(`<div>\n\thi\n\t<img src="a.jpg">\n\t<img src="b.jpg">\n\t<b>hi</b>\n</div>`);
+		)).to.equal(`<div>\n\thi\n\t<img src="a.jpg"/>\n\t<img src="b.jpg"/>\n\t<b>hi</b>\n</div>`);
 	});
 
 	it('should support empty tags', () => {

--- a/test/pretty.js
+++ b/test/pretty.js
@@ -55,7 +55,7 @@ describe('pretty', () => {
 				<img src="b.jpg" />
 				<b>hi</b>
 			</div>
-		)).to.equal(`<div>\n\thi\n\t<img src="a.jpg"/>\n\t<img src="b.jpg"/>\n\t<b>hi</b>\n</div>`);
+		)).to.equal(`<div>\n\thi\n\t<img src="a.jpg" />\n\t<img src="b.jpg" />\n\t<b>hi</b>\n</div>`);
 	});
 
 	it('should support empty tags', () => {

--- a/test/render.js
+++ b/test/render.js
@@ -53,14 +53,14 @@ describe('render', () => {
 
 		it('should self-close void elements', () => {
 			let rendered = render(<div><input type='text' /><wbr /></div>),
-				expected = `<div><input type="text"/><wbr/></div>`;
+				expected = `<div><input type="text" /><wbr /></div>`;
 
 			expect(rendered).to.equal(expected);
 		});
 
 		it('does not close void elements with closing tags', () => {
 			let rendered = render(<input><p>Hello World</p></input>),
-				expected = `<input/><p>Hello World</p>`;
+				expected = `<input /><p>Hello World</p>`;
 
 			expect(rendered).to.equal(expected);
 		});

--- a/test/render.js
+++ b/test/render.js
@@ -51,16 +51,16 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
-		it('does not close void elements', () => {
-			let rendered, expected;
-
-			rendered = render(<div><input type='text' /><wbr /></div>);
-			expected = `<div><input type="text"><wbr></div>`;
+		it('should self-close void elements', () => {
+			let rendered = render(<div><input type='text' /><wbr /></div>),
+				expected = `<div><input type="text"/><wbr/></div>`;
 
 			expect(rendered).to.equal(expected);
+		});
 
-			rendered = render(<input><p>Hello World</p></input>);
-			expected = `<input><p>Hello World</p>`;
+		it('does not close void elements with closing tags', () => {
+			let rendered = render(<input><p>Hello World</p></input>),
+				expected = `<input/><p>Hello World</p>`;
 
 			expect(rendered).to.equal(expected);
 		});


### PR DESCRIPTION
This fixes https://github.com/developit/preact-render-to-string/issues/24 by closing void element tags with a `/`. It updates relevant tests accordingly.