### PR TITLE
When styles object is empty don’t render style attribute

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -46,7 +46,7 @@ export function styleObjToCss(s) {
 			str += ';';
 		}
 	}
-	return str;
+	return str || undefined;
 }
 
 

--- a/test/render.js
+++ b/test/render.js
@@ -72,6 +72,13 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
+		it('should ignore empty object styles', () => {
+			let rendered = render(<div style={{}} />),
+				expected = `<div></div>`;
+
+			expect(rendered).to.equal(expected);
+		});
+
 		it('should render SVG elements', () => {
 			let rendered = render((
 				<svg>


### PR DESCRIPTION
Currently an empty styles object will server render the style attribute e.g. `<div style></div>` when what we really want is `<div></div>`. This is a slight inconsistency with React (and I think Preact?). 

This sounds quite benign but as we don't allow inline styles in our CSP rules the addition of this attribute is quite major.. especially as React Router's `Link` seems to default this to an empty object.