### PR TITLE
New: add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
   "scripts": {
-    "build": "npm run -s transpile && npm run -s transpile:jsx",
+    "build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
+    "copy-typescript-definition": "copyfiles -f src/index.d.ts dist",
     "transpile": "rollup -c rollup.config.js -m ${npm_package_main}.map -f umd -n $npm_package_amdName $npm_package_jsnext_main -o $npm_package_main",
     "transpile:jsx": "ENTRY=jsx rollup -c rollup.config.js -m dist/jsx.js.map -f umd -n $npm_package_amdName src/jsx.js -o dist/jsx.js",
     "test": "eslint src test && mocha --compilers js:babel-register test/**/*.js",
@@ -21,6 +22,7 @@
   ],
   "author": "Jason Miller <jason@developit.ca>",
   "license": "MIT",
+  "typings": "src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/developit/preact-render-to-string.git"
@@ -44,6 +46,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
+    "copyfiles": "^1.2.0",
     "eslint": "^3.2.2",
     "mocha": "^3.0.0",
     "preact": "^8.1.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,14 @@
+import { VNode } from 'preact';
+
+declare module render {
+  interface Options {
+    shallow:boolean;
+    xml:boolean;
+    pretty:boolean;
+  }
+
+  function render(vnode:VNode, context?:any, options?:Options):string;
+  function shallowRender(vnode:VNode, context?:any):string;
+}
+
+export = render;

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,5 @@
+{
+  "name": "preact-render-to-string",
+  "main": "src/index.d.ts",
+  "version": false
+}


### PR DESCRIPTION
- Try to mimic the Preact TSD.

- Example usage with `noImplicitAny` enabled:

  import { render } from "preact-render-to-string";

- No idea if I've done it right but it seems to compile and hopefully
  someone more knowledgeable can build on this.