### PR TITLE
Correct & simplify component name detection (Fixes #44)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,9 +206,8 @@ export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 }
 
 function getComponentName(component) {
-	let proto = component.prototype,
-		ctor = proto && proto.constructor;
-	return component.displayName || component.name || (proto && (proto.displayName || proto.name)) || getFallbackComponentName(component);
+	let ctor = component.prototype && component.prototype.constructor;
+	return ctor.displayName || ctor.name || getFallbackComponentName(component);
 }
 
 function getFallbackComponentName(component) {

--- a/src/index.js
+++ b/src/index.js
@@ -206,8 +206,7 @@ export default function renderToString(vnode, context, opts, inner, isSvgMode) {
 }
 
 function getComponentName(component) {
-	let ctor = component.prototype && component.prototype.constructor;
-	return ctor.displayName || ctor.name || getFallbackComponentName(component);
+	return component.displayName || component!==Function && component.name || getFallbackComponentName(component);
 }
 
 function getFallbackComponentName(component) {


### PR DESCRIPTION
The logic was really just incorrect, `displayName` and `name` will only ever exist on a component's constructor, not the prototype or instance.