### PR TITLE
Adds support for `getDerivedStateFromProps`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode) {
 				c._disable = c.__x = true;
 				c.props = props;
 				c.context = context;
-				if (c.constructor.getDerivedStateFromProps) c.state = assign(assign({}, c.state), c.constructor.getDerivedStateFromProps(c.props, c.state));
+				if (nodeName.getDerivedStateFromProps) c.state = assign(assign({}, c.state), nodeName.getDerivedStateFromProps(c.props, c.state));
 				else if (c.componentWillMount) c.componentWillMount();
 				rendered = c.render(c.props, c.state, c.context);
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,8 @@ function renderToString(vnode, context, opts, inner, isSvgMode) {
 				c._disable = c.__x = true;
 				c.props = props;
 				c.context = context;
-				if (c.componentWillMount) c.componentWillMount();
+				if (c.constructor.getDerivedStateFromProps) c.state = assign(assign({}, c.state), c.constructor.getDerivedStateFromProps(c.props, c.state));
+				else if (c.componentWillMount) c.componentWillMount();
 				rendered = c.render(c.props, c.state, c.context);
 
 				if (c.getChildContext) {

--- a/test/render.js
+++ b/test/render.js
@@ -310,6 +310,23 @@ describe('render', () => {
 			expect(render(<Test foo={undefined} bar="b" />), 'overridden').to.equal('<div foo="default foo" bar="b"></div>');
 		});
 
+		it('should invoke getDerivedStateFromProps', () => {
+			class Test extends Component {
+				static getDerivedStateFromProps() {}
+				render(props) {
+					return <div {...props} />;
+				}
+			}
+			spy(Test.prototype.constructor, 'getDerivedStateFromProps');
+			spy(Test.prototype, 'render');
+
+			render(<Test />);
+
+			expect(Test.prototype.constructor.getDerivedStateFromProps)
+				.to.have.been.calledOnce
+				.and.to.have.been.calledBefore(Test.prototype.render);
+		});
+
 		it('should invoke componentWillMount', () => {
 			class Test extends Component {
 				componentWillMount() {}
@@ -325,6 +342,27 @@ describe('render', () => {
 			expect(Test.prototype.componentWillMount)
 				.to.have.been.calledOnce
 				.and.to.have.been.calledBefore(Test.prototype.render);
+		});
+
+		it('should invoke getDerivedStateFromProps rather than componentWillMount', () => {
+			class Test extends Component {
+				static getDerivedStateFromProps() {}
+				componentWillMount() {}
+				render(props) {
+					return <div {...props} />;
+				}
+			}
+			spy(Test.prototype.constructor, 'getDerivedStateFromProps');
+			spy(Test.prototype, 'componentWillMount');
+			spy(Test.prototype, 'render');
+
+			render(<Test />);
+
+			expect(Test.prototype.constructor.getDerivedStateFromProps)
+				.to.have.been.calledOnce
+				.and.to.have.been.calledBefore(Test.prototype.render);
+			expect(Test.prototype.componentWillMount)
+				.to.not.have.been.called;
 		});
 
 		it('should pass context to grandchildren', () => {


### PR DESCRIPTION
Addresses Issue https://github.com/developit/preact-render-to-string/issues/62 by adding support for `getDerivedStateFromProps` which takes precedence over `componentWillMount`.

**`npm run build` (Before)**
> Build "preactRenderToString" to dist:
>       1.41 kB: index.mjs
>       1.45 kB: index.js

**`npm run build` (After)**
> Build "preactRenderToString" to dist:
>       1.45 kB: index.mjs
>       1.49 kB: index.js

Support was added to Preact with this PR https://github.com/developit/preact/pull/1094