### PR TITLE
Resolve crash when using hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "jsnext:main": "dist/index.mjs",
   "scripts": {
     "build": "npm run -s transpile && npm run -s transpile:jsx && npm run -s copy-typescript-definition",
-    "transpile": "echo 'export const ENABLE_PRETTY = false;'>env.js && microbundle src/index.js -f es,umd --target web --external none",
+    "transpile": "echo 'export const ENABLE_PRETTY = false;'>env.js && microbundle src/index.js -f es,umd --target web --external preact",
     "transpile:jsx": "echo 'export const ENABLE_PRETTY = true;'>env.js && microbundle src/jsx.js -o dist/jsx.js --target web --external none && microbundle dist/jsx.js -o dist/jsx.js -f cjs",
     "copy-typescript-definition": "copyfiles -f src/index.d.ts dist",
     "test": "eslint src test && mocha --compilers js:babel-register test/**/*.js",


### PR DESCRIPTION
This PR changes the external option for the build script from `none` to `preact` which resolves the crash when using hooks. (https://github.com/developit/preact/issues/1373)

The test for hooks ran fine when using the `src`, but crashed when using `dist` (the __h of undefined error). The reason for this was that with external option set to `none` resulted in the imported options from preact being an empty object (so `options.render` would not be called and hooks would crash). 

https://github.com/developit/preact-render-to-string/blob/8536c758e3d1808bcc18d64cd944da609531d11e/src/index.js#L66

Result difference in build:

**Before:** 
       `1510 B (mjs)`
       `1567 B (js)`

**After:**
	`1487 B (mjs)`
        `1549 B (js)`

**Difference:**
	`-23 B (mjs)`
	`-18 B (js)`
