### PR TITLE
Support createContext of preact x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 				let cctx = cxType != null ? (provider ? provider.props.value : cxType._defaultValue) : context;
 
 				// stateless functional components
-				rendered = nodeName.call(vnode.__c, props, cctx || context);
+				rendered = nodeName.call(vnode.__c, props, cctx);
 			}
 			else {
 				// class-based components

--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,14 @@ function renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 			if (options.render) options.render(vnode);
 
 			if (!nodeName.prototype || typeof nodeName.prototype.render!=='function') {
+				// Necessary for createContext api. Setting this property will pass
+				// the context value as `this.context` just for this component.
+				let cxType = nodeName.contextType;
+				let provider = cxType && context[cxType.__c];
+				let cctx = cxType != null ? (provider ? provider.props.value : cxType._defaultValue) : context;
+
 				// stateless functional components
-				rendered = nodeName.call(vnode.__c, props, context);
+				rendered = nodeName.call(vnode.__c, props, cctx || context);
 			}
 			else {
 				// class-based components

--- a/test/context.js
+++ b/test/context.js
@@ -1,0 +1,33 @@
+import render from '../src/jsx';
+import { h, createContext } from 'preact';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+// tag to remove leading whitespace from tagged template literal
+function dedent([str]) {
+	return str.split( '\n'+str.match(/^\n*(\s+)/)[1] ).join('\n').replace(/(^\n+|\n+\s*$)/g, '');
+}
+
+describe('context', () => {
+	let renderJsx = (jsx, opts) => render(jsx, null, opts).replace(/ {2}/g, '\t');
+
+	it('should support createContext', () => {
+		const { Provider, Consumer } = createContext();
+		let rendered = renderJsx(
+			<Provider value="correct">
+				<Consumer>
+					{(value) => (
+						<section>
+							value is: {value}
+						</section>
+					)}
+				</Consumer>
+			</Provider>
+		);
+
+		expect(rendered).to.equal(dedent`
+			<section>value is: correct</section>
+		`);
+	});
+});

--- a/test/context.js
+++ b/test/context.js
@@ -31,6 +31,27 @@ describe('context', () => {
 		`);
 	});
 
+	it('should support nested Providers', () => {
+		const { Provider, Consumer } = createContext();
+		let rendered = renderJsx(
+			<Provider value="wrong">
+				<Provider value="correct">
+					<Consumer>
+						{(value) => (
+							<section>
+								value is: {value}
+							</section>
+						)}
+					</Consumer>
+				</Provider>
+			</Provider>
+		);
+
+		expect(rendered).to.equal(dedent`
+			<section>value is: correct</section>
+		`);
+	});
+
 	it('should support falsy context value', () => {
 		const { Provider, Consumer } = createContext();
 		let rendered = renderJsx(

--- a/test/context.js
+++ b/test/context.js
@@ -30,4 +30,23 @@ describe('context', () => {
 			<section>value is: correct</section>
 		`);
 	});
+
+	it('should support falsy context value', () => {
+		const { Provider, Consumer } = createContext();
+		let rendered = renderJsx(
+			<Provider value={null}>
+				<Consumer>
+					{(value) => (
+						<section>
+							value is: {value}
+						</section>
+					)}
+				</Consumer>
+			</Provider>
+		);
+
+		expect(rendered).to.equal(dedent`
+			<section>value is: </section>
+		`);
+	});
 });


### PR DESCRIPTION
Adds support for createContext introduced by preact x.

I'm not sure whether these checks should also be introduced for class components. As the context consumer is currently a functional component it is sufficient to add the checks for these.

Fixes #73 